### PR TITLE
[FEATURE] add optional input for code src folder

### DIFF
--- a/.github/workflows/publish_on_pypi.yml
+++ b/.github/workflows/publish_on_pypi.yml
@@ -23,6 +23,10 @@ on:
         description: 'If true, the release on "real" pypi will be skipped.'
         type: boolean
         default: false
+      src_folder:
+        description: "Folder that contains the __init__.py file with the __version__ attribute. If not given,  `<packagename>/` is used"
+        type: string
+        default: ""
     secrets:
       test_pypi_api_token:
         description: 'PyPI token for the test API'
@@ -55,8 +59,13 @@ jobs:
         id: get_current_version
         shell: bash -l {0}
         run: |
-         CURRENT_VERSION=$(grep "__version__" ${{ inputs.package_name }}/__init__.py | cut -f3 -d ' ' | sed 's/"//g')
-         echo "new_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          if [ ! -z "${{ inputs.src_folder }}" ]; then  
+            init_file=${{ inputs.src_folder }}/__init__.py  
+          else
+            init_file=${{ inputs.package_name }}/__init__.py  
+          fi  
+          CURRENT_VERSION=$(grep "__version__" $init_file | cut -f3 -d ' ' | sed 's/"//g')
+          echo "new_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip


### PR DESCRIPTION
makes workflow adaptable to repos that have the following src structure src/<package_name>/code in addition to the currently implemented default <package_name>/code/.