### PR TITLE
Fix pypi release workflow

### DIFF
--- a/.github/workflows/publish_on_pypi.yml
+++ b/.github/workflows/publish_on_pypi.yml
@@ -55,6 +55,7 @@ jobs:
     steps:
       - name: get import_name
         id: get_import_name
+        shell: bash -l {0}
         run: |
           if [ -z "${{ inputs.import_name }}" ]; then
             echo "import_name=${{ inputs.package_name }}" >> $GITHUB_OUTPUT
@@ -173,6 +174,7 @@ jobs:
     steps:
       - name: get import_name
         id: get_import_name
+        shell: bash -l {0}
         run: |
           if [ -z "${{ inputs.import_name }}" ]; then
             echo "import_name=${{ inputs.package_name }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish_on_pypi.yml
+++ b/.github/workflows/publish_on_pypi.yml
@@ -157,7 +157,7 @@ jobs:
           conda env remove --name pip_stable_test -y
           conda clean --all -y
       - name: Publish distribution to PyPI
-        if: ${{ inputs.only_testpypi_release  == 'false' }}
+        if: ${{ inputs.only_testpypi_release  != 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/publish_on_pypi.yml
+++ b/.github/workflows/publish_on_pypi.yml
@@ -156,6 +156,7 @@ jobs:
           conda env remove --name pip_stable_test -y
           conda clean --all -y
       - name: Publish distribution to PyPI
+        if: ${{ inputs.only_testpypi_release  == 'false' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/publish_on_pypi.yml
+++ b/.github/workflows/publish_on_pypi.yml
@@ -170,6 +170,14 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: get import_name
+        id: get_import_name
+        run: |
+          if [ -z "${{ inputs.import_name }}" ]; then
+            echo "import_name=${{ inputs.package_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "import_name=${{ inputs.import_name }}" >> $GITHUB_OUTPUT
+          fi
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:


### PR DESCRIPTION
- ensure that import name is also assigned for the test workflow
- fix that upload to PyPI is only performed when the "only_testpypi_release" is != "true". In the previous version the upload was always performed.